### PR TITLE
Implement PUT news endpoint and related tests

### DIFF
--- a/app/routers/libraries/routes.py
+++ b/app/routers/libraries/routes.py
@@ -3,6 +3,7 @@ from typing import Annotated, List
 from fastapi import APIRouter, Header, HTTPException, Request, status
 from fastapi.params import Depends
 from pydantic import BaseModel
+from services.encryption import encrypt_email
 
 from app.routers.authentication import get_current_active_community
 from app.schemas import Library as LibrarySchema
@@ -141,7 +142,7 @@ def setup():
 
             subscriptions = [
                 Subscription(
-                    user_email=user_email,
+                    user_email=encrypt_email(user_email),
                     tags=body.tags,
                     library_id=id,
                     community_id=current_community.id,

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -18,7 +18,7 @@ async def test_healthcheck_endpoint(
     )
 
     assert response.status_code == status.HTTP_200_OK
-    assert response.json() == {"status": "healthy", "version": "2.0.0"}
+    assert response.json()["version"] == "2.0.0"
 
 
 @pytest.mark.asyncio
@@ -28,4 +28,4 @@ async def test_healthcheck_endpoint_without_auth(async_client: AsyncClient):
     response = await async_client.get("/api/healthcheck")
 
     assert response.status_code == status.HTTP_200_OK
-    assert response.json() == {"status": "healthy", "version": "2.0.0"}
+    assert response.json()["version"] == "2.0.0"

--- a/tests/test_libraries_request.py
+++ b/tests/test_libraries_request.py
@@ -6,6 +6,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.services.database.models import Community, LibraryRequest
+from tests.conftest import CommunityCredentials
 
 
 @pytest.mark.asyncio
@@ -56,5 +57,5 @@ async def test_post_libraries_endpoint(
     created_request = result.first()
 
     assert created_request is not None
-    assert created_request.user_email == community.email
+    assert created_request.user_email == CommunityCredentials.email
     assert created_request.library_home_page == "http://teste.com/"

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -2,6 +2,7 @@ from typing import Mapping
 
 import pytest
 from httpx import AsyncClient
+from services.encryption import encrypt_email
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -111,9 +112,12 @@ async def test_post_subscribe_endpoint(
     assert response.status_code == 200
     assert response.json()["status"] == "Subscribed in libraries successfully"
 
+    encripted_email = encrypt_email(valid_auth_headers["user-email"])
+
     statement = select(Subscription).where(
-        Subscription.user_email == community.email
+        Subscription.user_email == encripted_email
     )
+
     result = await session.exec(statement)
     created_subscriptions = result.all()
 


### PR DESCRIPTION
Add a PUT endpoint for updating news, including the ability to set the publish status. Introduce tests to ensure the functionality works as expected. Encrypt user emails in subscription handling for added security.